### PR TITLE
Fix value calculation in DailyBond

### DIFF
--- a/src/utils/DailyBond.ts
+++ b/src/utils/DailyBond.ts
@@ -21,6 +21,6 @@ export function loadOrCreateDailyBond(timestamp: BigInt, token: Token): DailyBon
 export function createDailyBondRecord(timestamp: BigInt, token: Token, amount: BigDecimal, value: BigDecimal): void{
     let dailyBond = loadOrCreateDailyBond(timestamp, token)
     dailyBond.amount = dailyBond.amount.plus(amount)
-    dailyBond.value = dailyBond.amount.plus(value)
+    dailyBond.value = dailyBond.value.plus(value)
     dailyBond.save()
 }


### PR DESCRIPTION
Some more suggestions:

1. Use `eventHandlers` instead of `callHandlers` for better performance (faster syncing)
2. Reuse `abis`, for most of those bonds share the same abi used in subgraph

by [MetaversePRO](https://app.metaverse.pro/) Dev Team.